### PR TITLE
Add Esperanto flag in SVG

### DIFF
--- a/countries.json
+++ b/countries.json
@@ -69,6 +69,7 @@
     "ES": "Spain",
     "ET": "Ethiopia",
     "EU": "Europe",
+    "EO": "Esperanto",
     "FI": "Finland",
     "FJ": "Fiji",
     "FK": "Falkland Islands (Malvinas)",

--- a/svg/eo.svg
+++ b/svg/eo.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 400"><path fill="#FFF" d="M0 0h202v202H0"/><path fill="#090" d="M0 200h200V0h400v400H0m58-243L99 31l41 126L33 79h133"/></svg>


### PR DESCRIPTION
Things added/changed:

- Added Esperanto flag in SVG format.

![Esperanto flag](https://user-images.githubusercontent.com/51391473/114345439-55c5fa80-9b27-11eb-8583-032dfaf0bfe8.png)
