### PR TITLE
Update name of FYROM to North Macedonia

### DIFF
--- a/countries.json
+++ b/countries.json
@@ -147,7 +147,7 @@
     "MF": "Saint Martin",
     "MG": "Madagascar",
     "MH": "Marshall Islands",
-    "MK": "Macedonia, the former Yugoslav Republic of",
+    "MK": "North Macedonia",
     "ML": "Mali",
     "MM": "Myanmar",
     "MN": "Mongolia",


### PR DESCRIPTION
Hi, great repo, thanks. Just wanted to mention that as of 2019, "Macedonia, the former Yugoslav Republic of" is now actually "North Macedonia"

(More info here: https://en.wikipedia.org/wiki/North_Macedonia)

The 2 letter code is still MK. 