### PR TITLE
make installable as Hugo Module

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,12 @@ You can also install this as a NPM module:
 
     npm install --save svg-country-flags
 
+You can also install it as a [Hugo Module](https://gohugo.io/hugo-modules) with:
+
+    hugo mod get github.com/privatemaker/country-flags
+
+Add adding the proper YAML to the `hugo.yaml` config file.
+
 
 ## Exporting to pngs
 

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/privatemaker/country-flags
+
+go 1.23.4


### PR DESCRIPTION
Hello 👋🏻 thanks for making this really helpful collection of flags 😄 

I made your repo installable in the [Hugo](https://gohugo.io) static site generator using their in-built module system. As you can see it is relatively minor addition.

I can update the paths to use your repo if you want to accept this. Otherwise, i'll leave it so other Hugo devs can install from my repo.